### PR TITLE
:bug: Fixed corenlp setup script backtick bug

### DIFF
--- a/setup_corenlp.sh
+++ b/setup_corenlp.sh
@@ -16,4 +16,4 @@ mv stanford-corenlp-4.0.0 $corenlp_dir
 curl https://nlp.stanford.edu/software/stanford-corenlp-4.0.0-models-$lang.jar -o $corenlp_dir/stanford-corenlp-4.0.0-models-$lang.jar
 
 echo "CoreNLP ($lang) successfully installed at $corenlp_dir"
-echo "Now and in the future, run `export CORENLP_HOME=$corenlp_dir` before using BlaBla or add this command to your .bashrc/.profile or equivalent file"
+echo "Now and in the future, run 'export CORENLP_HOME=$corenlp_dir' before using BlaBla or add this command to your .bashrc/.profile or equivalent file"


### PR DESCRIPTION
Backtick chars in setup bash script mean that the export env variable command isn't displayed correctly.