### PR TITLE
Smoother CLI experience

### DIFF
--- a/bin/blabla
+++ b/bin/blabla
@@ -7,7 +7,7 @@ import yaml
 import os
 from jsonschema import validate
 import pandas as pd
-
+from tqdm import tqdm
 
 features_json_schema = {
 	'type': 'object',
@@ -50,7 +50,7 @@ def compute_features(features_yaml_path, stanza_config_file_path, input_dir_path
 	with DocumentProcessor(
 		stanza_config_file_path, features_json['language']
 	) as doc_proc:
-		for input_fp in os.listdir(input_dir_path):
+		for input_fp in tqdm(os.listdir(input_dir_path)):
 			with open(os.path.join(input_dir_path, input_fp)) as f:
 				content = f.read()
 			doc = doc_proc.analyze(content, input_format)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
         "ipython==7.13.0",
         "jsonschema==3.2.0",
         "pyyaml==5.3.1",
-        "pandas==1.0.3"
+        "pandas==1.0.3",
+        "tqdm==4.46.0"
     ],
     package_data={"": ["*.txt"]},
     include_package_data=True,

--- a/stanza_config/stanza_config.yaml
+++ b/stanza_config/stanza_config.yaml
@@ -2,7 +2,7 @@ stanza:
     processors: 'tokenize,lemma,pos,mwt,depparse,ner'
     dir: 'stanza_resources'
 corenlp:
-    timeout: 30000
+    timeout: 300000
     memory: '4G'
     endpoint: 'http://localhost:9001'
-    be_quiet: False
+    be_quiet: True


### PR DESCRIPTION
Made CoreNLP quiet and have a longer timeout by default based on my experience using on a few hundred speaker transcripts. Added tqdm progress bar to CLI for usability.