### PR TITLE
Avoid TimeOut issues from CoreNLPClient

### DIFF
--- a/blabla/document_processor.py
+++ b/blabla/document_processor.py
@@ -37,7 +37,6 @@ class DocumentProcessor(object):
         self.client = CoreNLPClient(
             properties=language_properties_fp, **self.config["corenlp"]
         )
-        self.client.start()
         return self
 
     def break_json_into_chunks(self, doc_json):


### PR DESCRIPTION
**Issue(s) that your PR fixes** 
Explicitly starting the client-server was producing inconsistent TimeOut errors. We shouldn't need to manually start the server so have removed this command from the `__enter__` method of `DocumentProcessor`.

