### PR TITLE
Release BlaBla V0.2.2

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include blabla/language_resources/*.txt

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="blabla",
-    version="0.2.1",
+    version="0.2.2",
     description="Novoic linguistics feature extraction package.",
     url="http://github.com/novoic/BlaBla",
     author="Abhishek Shivkumar",
@@ -28,7 +28,7 @@ setup(
         "alzheimers-disease",
         "parkinsons-disease",
     ],
-    download_url="https://github.com/novoic/blabla/archive/v0.2.1.tar.gz",
+    download_url="https://github.com/novoic/blabla/archive/v0.2.2.tar.gz",
     install_requires=[
         "stanza==1.0.0",
         "flask==1.1.2",
@@ -41,7 +41,7 @@ setup(
         "pandas==1.0.3",
         "tqdm==4.46.0"
     ],
-    package_data={"": ["*.txt"]},
+    package_data={"blabla.language_resources": ["*.txt"]},
     include_package_data=True,
     scripts=["bin/blabla"],
     zip_safe=False,


### PR DESCRIPTION
CHANGES:

a. Fixed a bug that did not copy the language resources files during BlaBla setup from PyPi.
b. Created a MANIFEST.in a file that contains the paths to the language_resources files for setup.