### PR TITLE
:pencil: Updating the README for PyTorch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ To install BlaBla using PyPI:
 ```bash
 pip install blabla
 ```
+BlaBla currently supports only PyTorch version 1.5.1. Once you install BlaBla using the above steps, please make sure that your PyTorch version is 1.5.1. Otherwise please install PyTorch version 1.5.1 using the following command
 
+```bash
+pip install torch==1.5.1
+```
 
 ### Installing CoreNLP
 For some features, BlaBla also requires [Stanford CoreNLP](https://stanfordnlp.github.io/CoreNLP/) to be installed. See `FEATURES.md` for a list of these features.


### PR DESCRIPTION
CHANGES:

BlaBla needs PyTorch to run. PyTorch is installed automatically from Stanza when we install BlaBla. With the release of PyTorch v1.6 recently, it has been observed that Stanza breaks while processing sentences for dependency parse trees. 

This update to README clarifies the above point and mentions that the user has to force install PyTorch v1.5.1 if the version of PyTorch is anything different once BlaBla is installed.